### PR TITLE
[NO ISSUE] Versioning updates for 1.0

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -36,7 +36,7 @@ for other platforms, consider our xref:tableau-connector::index.adoc[Tableau con
 
 == Install the Couchbase ODBC Driver
 
-. Download the `couchbase-odbc-1.1-win64.msi` file from https://packages.couchbase.com/releases/couchbase-odbc-driver/1.1/couchbase-odbc-1.1-win64.msi[] -- see the xref:release-notes.adoc[release notes page] for more details.
+. Download the `couchbase-odbc-1.0-win64.msi` file from https://packages.couchbase.com/releases/couchbase-odbc-driver/1.0/couchbase-odbc-1.0-win64.msi[] -- see the xref:release-notes.adoc[release notes page] for more details.
 
 . Double-click the file to open the *Couchbase ODBC Setup Wizard*.
 
@@ -51,8 +51,7 @@ The connection between a Couchbase Analytics instance or a Capella columnar data
 OpenSSL is a required dependency for the driver.
 
 
-. Download OpenSSL 3.x for x64 (recommended version: OpenSSL 3.5.x Light -- the current LTS version)
- from the link:https://slproweb.com/products/Win32OpenSSL.html[Shining Light Productions site].
+. Download `Win64OpenSSL_Light-1_1_1v.msi` from the https://slproweb.com/products/Win32OpenSSL.html[Shining Light Productions site].
 
 . Install OpenSSL from the downloaded file.
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -10,19 +10,6 @@ and either Couchbase Analytics Service (CBAS) or tabular views of your Capella c
 
 For self-managed CBAS, the Power BI connector requires Couchbase Server 7.2.4 or newer.
 
-[#v-1-1]
-== Version 1.1 (2024-06-12)
-
-https://packages.couchbase.com/releases/couchbase-powerbi-connector/1.0/couchbase-powerbi-connector-1.0.mez[Power BI Connector Download]
-
-The supported and tested dependencies of this release are:
-
-* https://packages.couchbase.com/releases/couchbase-odbc-driver/1.1/couchbase-odbc-1.1-win64.msi[couchbase-odbc-1.1-win64.msi]
-
-** See the https://packages.couchbase.com/releases/couchbase-odbc-driver/1.1/couchbase-odbc-driver-1.1-notices.txt[Notices File] for dependency licenses for the ODBC Driver.
-
-* https://slproweb.com/download/Win64OpenSSL_Light-3_3_1.msi[Win64 OpenSSL v3.3.x Light]
-
 [#v-1-0]
 == Version 1.0 (2024-01-25)
 


### PR DESCRIPTION
Updates for the `release/1.0` branch. 

Changes:
- Updated release notes to remove 1.1 content. 
- Set the the ODBC version to 1.0. 
- Reverted/updated the OpenSSL version.
- No changes required for `antora.yml`.

Branch `main` will be renamed to `release/1.0` after merge. 